### PR TITLE
Store entities on context and trigger post-processors after the import

### DIFF
--- a/lib/solidus_importer.rb
+++ b/lib/solidus_importer.rb
@@ -8,7 +8,7 @@ require 'solidus_importer/exception'
 require 'solidus_importer/base_importer'
 
 require 'solidus_importer/processors/base'
-processors = File.join(__dir__, 'solidus_importer/processors/*.rb')
+processors = File.join(__dir__, 'solidus_importer/*processors/*.rb')
 Dir[processors].each { |file| require file }
 
 require 'solidus_importer/configuration'

--- a/lib/solidus_importer/base_importer.rb
+++ b/lib/solidus_importer/base_importer.rb
@@ -10,6 +10,10 @@ module SolidusImporter
       @options[:processors] || []
     end
 
+    def post_processors
+      @options[:post_processors] || []
+    end
+
     ##
     # Defines a method called before the import process is started.
     # Remember to always return a context with `success` key.
@@ -21,6 +25,10 @@ module SolidusImporter
 
     ##
     # Defines a method called after the import process is started
-    def after_import(_ending_context); end
+    def after_import(ending_context)
+      post_processors.each do |post_processor|
+        post_processor.call(ending_context)
+      end
+    end
   end
 end

--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -16,6 +16,9 @@ module SolidusImporter
         processors: [
           SolidusImporter::Processors::Order,
           SolidusImporter::Processors::Log
+        ],
+        post_processors: [
+          SolidusImporter::PostProcessors::OrdersRecalculator
         ]
       },
       products: {

--- a/lib/solidus_importer/post_processors/orders_recalculator.rb
+++ b/lib/solidus_importer/post_processors/orders_recalculator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SolidusImporter
+  module PostProcessors
+    class OrdersRecalculator < SolidusImporter::Processors::Base
+      def call(ending_context)
+        ending_context[:orders].each do |order|
+          order.becomes(Spree::Order).recalculate
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_importer/post_processors/orders_recalculator.rb
+++ b/lib/solidus_importer/post_processors/orders_recalculator.rb
@@ -4,8 +4,8 @@ module SolidusImporter
   module PostProcessors
     class OrdersRecalculator < SolidusImporter::Processors::Base
       def call(ending_context)
-        ending_context[:orders].each do |order|
-          order.becomes(Spree::Order).recalculate
+        ending_context[:order_ids].each do |id|
+          Spree::Order.find(id).recalculate
         end
       end
     end

--- a/lib/solidus_importer/process_import.rb
+++ b/lib/solidus_importer/process_import.rb
@@ -26,6 +26,7 @@ module SolidusImporter
       initial_context = @importer.before_import(initial_context)
       unless @import.failed?
         rows = process_rows(initial_context)
+        importer.after_import(initial_context)
         @import.update(state: :completed) if rows.zero?
       end
       @import

--- a/lib/solidus_importer/process_row.rb
+++ b/lib/solidus_importer/process_row.rb
@@ -12,7 +12,7 @@ module SolidusImporter
     end
 
     def process(initial_context)
-      context = initial_context.dup.merge!(row_id: @row.id, importer: @importer, data: @row.data)
+      context = initial_context.merge!(row_id: @row.id, importer: @importer, data: @row.data)
       @importer.processors.each do |processor|
         begin
           processor.call(context)

--- a/lib/solidus_importer/process_row.rb
+++ b/lib/solidus_importer/process_row.rb
@@ -34,7 +34,6 @@ module SolidusImporter
     def check_import_finished(context)
       return unless @row.import.finished?
 
-      @importer.after_import(context)
       @row.import.update!(state: (@row.import.rows.failed.any? ? :failed : :completed))
     end
 

--- a/lib/solidus_importer/processors/order.rb
+++ b/lib/solidus_importer/processors/order.rb
@@ -6,7 +6,10 @@ module SolidusImporter
       def call(context)
         @data = context.fetch(:data)
         check_data
-        context.merge!(order: process_order)
+
+        context[:order] = process_order
+        context[:orders] ||= []
+        context[:orders] << context[:order]
       end
 
       def options

--- a/lib/solidus_importer/processors/order.rb
+++ b/lib/solidus_importer/processors/order.rb
@@ -8,8 +8,8 @@ module SolidusImporter
         check_data
 
         context[:order] = process_order
-        context[:orders] ||= []
-        context[:orders] << context[:order]
+        context[:order_ids] ||= []
+        context[:order_ids] << context[:order].id
       end
 
       def options

--- a/spec/features/solidus_importer/processors_spec.rb
+++ b/spec/features/solidus_importer/processors_spec.rb
@@ -26,23 +26,24 @@ RSpec.describe 'Set up a some processors' do # rubocop:disable RSpec/DescribeCla
   let(:import_source) { create(:solidus_importer_import_customers) }
   let(:importer_options) do
     {
-      importer: CustomImporter,
+      importer: importer_class,
       processors: [processor_create_user, processor_check_domain]
     }
   end
-  let(:importer) { CustomImporter.new(importer_options) }
-
-  before do
-    stub_const('CustomImporter', SolidusImporter::BaseImporter)
-    CustomImporter.class_eval do
+  let(:importer) { importer_class.new(importer_options) }
+  let(:importer_class) do
+    Class.new(SolidusImporter::BaseImporter) do
       attr_accessor :checks
 
       def after_import(ending_context)
         ending_context[:importer].checks
       end
     end
+  end
+
+  before do
     importer
-    allow(CustomImporter).to receive(:new).and_return(importer)
+    allow(importer_class).to receive(:new).and_return(importer)
     allow(importer).to receive(:after_import).and_call_original
   end
 

--- a/spec/lib/solidus_importer/base_importer_spec.rb
+++ b/spec/lib/solidus_importer/base_importer_spec.rb
@@ -7,8 +7,17 @@ RSpec.describe SolidusImporter::BaseImporter do
 
   let(:options) { {} }
 
-  describe '#after_import' do
-    it { is_expected.to respond_to(:after_import) }
+  describe '#after_import without order' do
+    subject(:described_method) { described_instance.after_import(context) }
+
+    let(:context) { {} }
+    let(:post_processor) { spy }
+
+    it 'execute post_processors' do
+      expect(described_instance).to receive(:post_processors).and_return([post_processor])
+      described_method
+      expect(post_processor).to have_received(:call).with(context)
+    end
   end
 
   describe '#before_import' do

--- a/spec/lib/solidus_importer/post_processors/orders_recalculator_spec.rb
+++ b/spec/lib/solidus_importer/post_processors/orders_recalculator_spec.rb
@@ -5,13 +5,13 @@ require 'spec_helper'
 RSpec.describe SolidusImporter::PostProcessors::OrdersRecalculator do
   describe '#call' do
     subject(:described_method) { described_class.call(context) }
-
-    let(:context) { { orders: [order] } }
-    let(:order) { spy }
+    let(:order) { build(:order) }
+    let(:context) { { order_ids: [123] } }
 
     it 'execute post_processors' do
+      expect(Spree::Order).to receive(:find).with(123).and_return(order)
+      expect(order).to receive(:recalculate)
       described_method
-      expect(order).to have_received(:recalculate)
     end
   end
 end

--- a/spec/lib/solidus_importer/post_processors/orders_recalculator_spec.rb
+++ b/spec/lib/solidus_importer/post_processors/orders_recalculator_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusImporter::PostProcessors::OrdersRecalculator do
+  describe '#call' do
+    subject(:described_method) { described_class.call(context) }
+
+    let(:context) { { orders: [order] } }
+    let(:order) { spy }
+
+    it 'execute post_processors' do
+      described_method
+      expect(order).to have_received(:recalculate)
+    end
+  end
+end

--- a/spec/lib/solidus_importer/process_import_spec.rb
+++ b/spec/lib/solidus_importer/process_import_spec.rb
@@ -25,16 +25,25 @@ RSpec.describe SolidusImporter::ProcessImport do
     end
 
     context 'with some rows' do
+      let(:importer) { SolidusImporter::BaseImporter.new({}) }
       let(:process_row) { instance_double(::SolidusImporter::ProcessRow, process: nil) }
       let(:rows) { build_list(:solidus_importer_row_customer, 3) }
       let(:import) { create(:solidus_importer_import_customers, rows: rows) }
 
       before do
         allow(::SolidusImporter::ProcessRow).to receive_messages(new: process_row)
-        described_method
+        allow(SolidusImporter::BaseImporter).to receive(:new).and_return(importer)
       end
 
-      it { expect(::SolidusImporter::ProcessRow).to have_received(:new).exactly(rows_count).times }
+      it do
+        described_method
+        expect(::SolidusImporter::ProcessRow).to have_received(:new).exactly(rows_count).times
+      end
+
+      it 'calls after_import' do
+        expect(importer).to receive(:after_import)
+        described_method
+      end
     end
 
     context 'with completed rows' do

--- a/spec/lib/solidus_importer/process_row_spec.rb
+++ b/spec/lib/solidus_importer/process_row_spec.rb
@@ -21,4 +21,17 @@ RSpec.describe SolidusImporter::ProcessRow do
       it { expect(described_instance).to be_instance_of(described_class) }
     end
   end
+
+  describe '#process' do
+    subject(:process) { described_instance.process(context) }
+
+    let(:row) { create(:solidus_importer_row_order, import: import) }
+    let(:import) { create(:solidus_importer_import_orders) }
+    let(:importer) { SolidusImporter::BaseImporter.new({}) }
+    let(:context) { {} }
+
+    it 'preserve the context' do
+      expect(process).to be_equal(context)
+    end
+  end
 end

--- a/spec/lib/solidus_importer/processors/order_spec.rb
+++ b/spec/lib/solidus_importer/processors/order_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe SolidusImporter::Processors::Order do
       it 'creates a new order' do
         expect { described_method }.to change { Spree::Order.count }.by(1)
         expect(context).to have_key(:order)
-        expect(context).to have_key(:orders)
+        expect(context).to have_key(:order_ids)
       end
 
       context 'with an existing valid order' do
@@ -38,7 +38,7 @@ RSpec.describe SolidusImporter::Processors::Order do
         it 'updates the order' do
           expect { described_method }.not_to(change{ Spree::Order.count })
           expect(context).to have_key(:order)
-          expect(context).to have_key(:orders)
+          expect(context).to have_key(:order_ids)
           expect(order.reload.email).to eq('an_email@example.com')
         end
       end

--- a/spec/lib/solidus_importer/processors/order_spec.rb
+++ b/spec/lib/solidus_importer/processors/order_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe SolidusImporter::Processors::Order do
         { data: data }
       end
       let(:data) { build(:solidus_importer_row_order, :with_import).data }
-      let(:result) { context.merge(order: Spree::Order.last) }
 
       before { allow(Spree::Store).to receive(:default).and_return(build_stubbed(:store)) }
 
       it 'creates a new order' do
         expect { described_method }.to change { Spree::Order.count }.by(1)
-        expect(described_method).to eq(result)
+        expect(context).to have_key(:order)
+        expect(context).to have_key(:orders)
       end
 
       context 'with an existing valid order' do
@@ -37,7 +37,8 @@ RSpec.describe SolidusImporter::Processors::Order do
 
         it 'updates the order' do
           expect { described_method }.not_to(change{ Spree::Order.count })
-          expect(described_method).to eq(result)
+          expect(context).to have_key(:order)
+          expect(context).to have_key(:orders)
           expect(order.reload.email).to eq('an_email@example.com')
         end
       end


### PR DESCRIPTION
In this way we can define some custom post-processors to process the context after all rows are being processed. To make it works, the context is now preserved between rows processing.
We also add a basic post-processor which invokes `#recaulculate` for all created **orders**. 