### PR TITLE
Try out the leaner orb cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   # run specs against Solidus supported versions only without the need
   # to change this configuration every time a Solidus version is released
   # or goes EOL.
-  solidusio_extensions: solidusio/extensions@volatile
+  solidusio_extensions: solidusio/extensions@dev:bf50fb9
 
 jobs:
   run-specs-with-postgres:


### PR DESCRIPTION
see https://github.com/solidusio/circleci-orbs-extensions/pull/28

- [First run (required installing gems from scratch): 25min](https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_importer/270/workflows/3f08bf0c-163d-45c2-a29a-c37cce7c69ba/jobs/567)
- [Second run (with the cache hit): less than 7min](https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_importer/272/workflows/91ab5c28-51eb-4a6c-83e7-068eb1ef8ed1/jobs/571)