### PR TITLE
Update binstubs

### DIFF
--- a/bin/rails-sandbox
+++ b/bin/rails-sandbox
@@ -5,7 +5,7 @@ app_root = 'sandbox'
 unless File.exist? "#{app_root}/bin/rails"
   warn 'Creating the sandbox app...'
   Dir.chdir "#{__dir__}/.." do
-    system "#{__dir__}/sandbox" or begin # rubocop:disable Style/AndOr
+    system "#{__dir__}/sandbox" or begin
       warn 'Automatic creation of the sandbox app failed'
       exit 1
     end

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -72,9 +72,11 @@ unbundled bundle exec rails generate spree:install \
   --user_class=Spree::User \
   --enforce_available_locales=true \
   --with-authentication=false \
+  --payment-method=none
   $@
 
 unbundled bundle exec rails generate solidus:auth:install
+unbundled bundle exec rails generate ${extension_name}:install
 
 echo
 echo "🚀 Sandbox app successfully created for $extension_name!"


### PR DESCRIPTION
via `solidus extension .`

otherwise sandbox commands returns

        Could not find gem 'solidus_paypal_commerce_platform' in any of the gem sources listed in your Gemfile.
        Run `bundle install` to install missing gems.

Ref. https://github.com/solidusio/solidus/pull/3751