### PR TITLE
Enhance order importer

### DIFF
--- a/app/models/solidus_importer/order_updater.rb
+++ b/app/models/solidus_importer/order_updater.rb
@@ -1,0 +1,6 @@
+module SolidusImporter
+  class OrderUpdater < Spree::OrderUpdater
+    # Override this method to avoid tax calculation
+    def update_taxes; end
+  end
+end

--- a/app/models/solidus_importer/spree_core_importer_order.rb
+++ b/app/models/solidus_importer/spree_core_importer_order.rb
@@ -1,0 +1,49 @@
+module SolidusImporter
+  class SpreeCoreImporterOrder < Spree::Core::Importer::Order
+    def self.import(user, params)
+      params = params.to_h
+      ActiveRecord::Base.transaction do
+        ensure_country_id_from_params params[:ship_address_attributes]
+        ensure_state_id_from_params params[:ship_address_attributes]
+        ensure_country_id_from_params params[:bill_address_attributes]
+        ensure_state_id_from_params params[:bill_address_attributes]
+
+        create_params = params.slice :currency
+        order = Spree::Order.create! create_params
+        order.store ||= Spree::Store.default
+        order.associate_user!(user)
+        order.save!
+
+        shipments_attrs = params.delete(:shipments_attributes)
+
+        create_line_items_from_params(params.delete(:line_items_attributes), order)
+        create_shipments_from_params(shipments_attrs, order)
+        create_adjustments_from_params(params.delete(:adjustments_attributes), order)
+        create_payments_from_params(params.delete(:payments_attributes), order)
+
+        params.delete(:user_id) unless user.try(:has_spree_role?, "admin") && params.key?(:user_id)
+
+        completed_at = params.delete(:completed_at)
+
+        order.update!(params)
+
+        order.create_proposed_shipments unless shipments_attrs.present?
+
+        if completed_at
+          order.completed_at = completed_at
+          order.state = 'complete'
+          order.save!
+        end
+
+        # Really ensure that the order totals & states are correct
+        order.updater.update
+        if shipments_attrs.present?
+          order.shipments.each_with_index do |shipment, index|
+            shipment.update_columns(cost: shipments_attrs[index][:cost].to_f) if shipments_attrs[index][:cost].present?
+          end
+        end
+        order.reload
+      end
+    end
+  end
+end

--- a/app/models/solidus_importer/spree_core_importer_order.rb
+++ b/app/models/solidus_importer/spree_core_importer_order.rb
@@ -36,7 +36,8 @@ module SolidusImporter
         end
 
         # Really ensure that the order totals & states are correct
-        order.updater.update
+        updater = SolidusImporter::OrderUpdater.new(order)
+        updater.update
         if shipments_attrs.present?
           order.shipments.each_with_index do |shipment, index|
             shipment.update_columns(cost: shipments_attrs[index][:cost].to_f) if shipments_attrs[index][:cost].present?

--- a/lib/solidus_importer/base_importer.rb
+++ b/lib/solidus_importer/base_importer.rb
@@ -21,7 +21,8 @@ module SolidusImporter
 
     ##
     # Defines a method called after the import process is finished
-    def after_import
+    def after_import(context)
+      context
     end
 
     ##

--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -17,6 +17,7 @@ module SolidusImporter
           SolidusImporter::Processors::Order,
           SolidusImporter::Processors::BillAddress,
           SolidusImporter::Processors::ShipAddress,
+          SolidusImporter::Processors::LineItem,
           SolidusImporter::Processors::Log
         ]
       },

--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -19,6 +19,7 @@ module SolidusImporter
           SolidusImporter::Processors::ShipAddress,
           SolidusImporter::Processors::LineItem,
           SolidusImporter::Processors::Shipment,
+          SolidusImporter::Processors::Payment,
           SolidusImporter::Processors::Log
         ]
       },

--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -16,6 +16,7 @@ module SolidusImporter
         processors: [
           SolidusImporter::Processors::Order,
           SolidusImporter::Processors::BillAddress,
+          SolidusImporter::Processors::ShipAddress,
           SolidusImporter::Processors::Log
         ]
       },

--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -15,6 +15,7 @@ module SolidusImporter
         importer: SolidusImporter::OrderImporter,
         processors: [
           SolidusImporter::Processors::Order,
+          SolidusImporter::Processors::BillAddress,
           SolidusImporter::Processors::Log
         ]
       },

--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -18,6 +18,7 @@ module SolidusImporter
           SolidusImporter::Processors::BillAddress,
           SolidusImporter::Processors::ShipAddress,
           SolidusImporter::Processors::LineItem,
+          SolidusImporter::Processors::Shipment,
           SolidusImporter::Processors::Log
         ]
       },

--- a/lib/solidus_importer/order_importer.rb
+++ b/lib/solidus_importer/order_importer.rb
@@ -16,8 +16,12 @@ module SolidusImporter
 
       return unless number
 
-      order_params = context[:order].to_h.reject { |_k, v| v.blank? }
       orders[number] ||= {}
+
+      order_params = context[:order].to_h.reject { |_k, v| v.blank? }
+      payments_attributes = order_params[:payments_attributes]
+      orders[number][:payments_attributes] ||= []
+      orders[number][:payments_attributes] << payments_attributes if payments_attributes.present?
       orders[number].merge!(order_params)
     end
 

--- a/lib/solidus_importer/order_importer.rb
+++ b/lib/solidus_importer/order_importer.rb
@@ -28,7 +28,7 @@ module SolidusImporter
     def after_import(context)
       orders.each do |_, params|
         user = params.delete(:user)
-        Spree::Core::Importer::Order.import(user, params)
+        SolidusImporter::SpreeCoreImporterOrder.import(user, params)
       rescue StandardError
         context[:success] = false
       end

--- a/lib/solidus_importer/order_importer.rb
+++ b/lib/solidus_importer/order_importer.rb
@@ -4,19 +4,28 @@ require 'set'
 
 module SolidusImporter
   class OrderImporter < BaseImporter
-    attr_accessor :order_ids
+    attr_accessor :orders
 
     def initialize(options)
       super
-      self.order_ids = Set.new
+      self.orders = {}
     end
 
     def handle_row_import(context)
-      order_ids << context[:order]&.id
+      number = context.dig(:order, :number)
+
+      return unless number
+
+      order_params = context[:order].to_h.reject { |_k, v| v.blank? }
+      orders[number] ||= {}
+      orders[number].merge!(order_params)
     end
 
     def after_import
-      Spree::Order.where(id: order_ids).find_each(&:recalculate)
+      orders.each do |_, params|
+        user = params.delete(:user)
+        Spree::Core::Importer::Order.import(user, params)
+      end
     end
   end
 end

--- a/lib/solidus_importer/order_importer.rb
+++ b/lib/solidus_importer/order_importer.rb
@@ -21,11 +21,15 @@ module SolidusImporter
       orders[number].merge!(order_params)
     end
 
-    def after_import
+    def after_import(context)
       orders.each do |_, params|
         user = params.delete(:user)
         Spree::Core::Importer::Order.import(user, params)
+      rescue StandardError
+        context[:success] = false
       end
+
+      context
     end
   end
 end

--- a/lib/solidus_importer/process_import.rb
+++ b/lib/solidus_importer/process_import.rb
@@ -26,8 +26,11 @@ module SolidusImporter
       initial_context = @importer.before_import(initial_context)
       unless @import.failed?
         rows = process_rows(initial_context)
-        @importer.after_import
-        @import.update(state: :completed) if rows.zero?
+        ending_context = @importer.after_import(initial_context)
+        state = @import.state
+        state = :completed if rows.zero?
+        state = :failed if ending_context[:success] == false
+        @import.update(state: state)
       end
       @import
     end

--- a/lib/solidus_importer/processors/bill_address.rb
+++ b/lib/solidus_importer/processors/bill_address.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module SolidusImporter
+  module Processors
+    class BillAddress < Base
+      def call(context)
+        @data = context[:data]
+
+        return if @data['Billing Address1'].blank?
+
+        order = context.fetch(:order, {})
+
+        order[:bill_address_attributes] = bill_address_attributes
+
+        context.merge!(order: order)
+      end
+
+      private
+
+      def country_code
+        @data['Billing Country Code']
+      end
+
+      def province_code
+        @data['Billing Province Code']
+      end
+
+      def bill_address_attributes
+        {
+          firstname: @data['Billing First Name'],
+          lastname: @data['Billing Last Name'],
+          address1: @data['Billing Address1'],
+          address2: @data['Billing Address2'],
+          city: @data['Billing City'],
+          company: @data['Billing Company'],
+          zipcode: @data['Billing Zip'],
+          phone: @data['Billing Phone'],
+          country: country,
+          state: state
+        }
+      end
+
+      def country
+        @country ||= Spree::Country.find_by(iso: country_code) if country_code
+      end
+
+      def state
+        @state ||= country&.states&.find_by(abbr: province_code) if province_code
+      end
+    end
+  end
+end

--- a/lib/solidus_importer/processors/line_item.rb
+++ b/lib/solidus_importer/processors/line_item.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SolidusImporter
+  module Processors
+    class LineItem < Base
+      def call(context)
+        @data = context[:data]
+
+        return if @data['Lineitem sku'].blank?
+
+        order = context.fetch(:order, {})
+
+        order[:line_items_attributes] ||= {}
+
+        index = order[:line_items_attributes].size
+
+        order[:line_items_attributes][index] = line_items_attributes
+
+        context.merge!(order: order)
+      end
+
+      private
+
+      def line_items_attributes
+        {
+          sku: @data['Lineitem sku'],
+          quantity: @data['Lineitem quantity'],
+          price: @data['Lineitem price']
+        }
+      end
+    end
+  end
+end

--- a/lib/solidus_importer/processors/order.rb
+++ b/lib/solidus_importer/processors/order.rb
@@ -6,7 +6,7 @@ module SolidusImporter
       def call(context)
         @data = context.fetch(:data)
         check_data
-        context.merge!(order: process_order)
+        context.merge!(order: order_attributes)
       end
 
       def options
@@ -21,19 +21,48 @@ module SolidusImporter
         raise SolidusImporter::Exception, 'Missing required key: "Name"' if @data['Name'].blank?
       end
 
-      def prepare_order
-        Spree::Order.find_or_initialize_by(number: @data['Name']) do |order|
-          order.store = options[:store]
-        end.tap do |order|
-          # Apply the row attributes
-          order.currency = @data['Currency'] unless @data['Currency'].nil?
-          order.email = @data['Email'] unless @data['Email'].nil?
-          order.special_instructions = @data['Note'] unless @data['Note'].nil?
-        end
+      def completed_at
+        processed_at = @data['Processed At']
+        processed_at ? Time.parse(processed_at).in_time_zone : Time.current
+      rescue ArgumentError
+        Time.current
       end
 
-      def process_order
-        prepare_order.tap(&:save!)
+      def currency
+        @data['Currency']
+      end
+
+      def email
+        @data['Email']
+      end
+
+      def order_attributes
+        {
+          number: number,
+          completed_at: completed_at,
+          store: options[:store],
+          currency: currency,
+          email: email,
+          user: user,
+          special_instructions: special_instruction,
+          line_items_attributes: {},
+          bill_address_attributes: {},
+          ship_address_attributes: {},
+          shipments_attributes: [],
+          payments_attributes: []
+        }
+      end
+
+      def number
+        @data['Name']
+      end
+
+      def special_instruction
+        @data['Note']
+      end
+
+      def user
+        @user ||= Spree::User.find_by(email: email)
       end
     end
   end

--- a/lib/solidus_importer/processors/payment.rb
+++ b/lib/solidus_importer/processors/payment.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative 'line_item'
+
+module SolidusImporter
+  module Processors
+    class Payment < Base
+      attr_accessor :order
+
+      def call(context)
+        @data = context.fetch(:data)
+
+        return unless amount > 0
+
+        self.order = context.fetch(:order, {})
+
+        order[:payments_attributes] ||= []
+        order[:payments_attributes] << payment_attributes
+
+        context.merge!(order: order)
+      end
+
+      private
+
+      def amount
+        price * quantity
+      end
+
+      def price
+        @data['Lineitem price'].to_f
+      end
+
+      def quantity
+        @data['Lineitem quantity'].to_i
+      end
+
+      def financial_status
+        @data['Financial Status'].to_s.inquiry
+      end
+
+      def payment_attributes
+        {
+          payment_method: payment_method.name,
+          amount: amount
+        }
+      end
+
+      def payment_method
+        @payment_method ||= Spree::PaymentMethod.find_or_initialize_by(
+          name: 'SolidusImporter PaymentMethod',
+          type: 'Spree::PaymentMethod::Check'
+        ).tap(&:save)
+      end
+    end
+  end
+end

--- a/lib/solidus_importer/processors/ship_address.rb
+++ b/lib/solidus_importer/processors/ship_address.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module SolidusImporter
+  module Processors
+    class ShipAddress < Base
+      def call(context)
+        @data = context[:data]
+
+        return if @data['Shipping Address1'].blank?
+
+        order = context.fetch(:order, {})
+
+        order[:ship_address_attributes] = ship_address_attributes
+
+        context.merge!(order: order)
+      end
+
+      private
+
+      def country_code
+        @data['Shipping Country Code']
+      end
+
+      def province_code
+        @data['Shipping Province Code']
+      end
+
+      def ship_address_attributes
+        {
+          firstname: @data['Shipping First Name'],
+          lastname: @data['Shipping Last Name'],
+          address1: @data['Shipping Address1'],
+          address2: @data['Shipping Address2'],
+          city: @data['Shipping City'],
+          company: @data['Shipping Company'],
+          zipcode: @data['Shipping Zip'],
+          phone: @data['Shipping Phone'],
+          country: country,
+          state: state,
+        }
+      end
+
+      def country
+        @country ||= Spree::Country.find_by(iso: country_code) if country_code
+      end
+
+      def state
+        @state ||= country&.states&.find_by(abbr: province_code) if province_code
+      end
+    end
+  end
+end

--- a/lib/solidus_importer/processors/shipment.rb
+++ b/lib/solidus_importer/processors/shipment.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module SolidusImporter
+  module Processors
+    class Shipment < Base
+      attr_accessor :order
+
+      def call(context)
+        @data = context.fetch(:data)
+
+        self.order = context.fetch(:order, {})
+        order[:shipments_attributes] ||= []
+        order[:shipments_attributes] << shipments_attributes
+
+        context.merge!(order: order)
+      end
+
+      private
+
+      def cost
+        @data['Shipping Line Price'].to_f
+      end
+
+      def inventory_units
+        line_items_attributes.map do |_, line_item|
+          { sku: line_item[:sku] }
+        end
+      end
+
+      def line_items_attributes
+        order.fetch(:line_items_attributes, [])
+      end
+
+      def shipments_attributes
+        {
+          shipped_at: shipped_at,
+          shipping_method: shipping_method.name,
+          stock_location: stock_location.name,
+          inventory_units: inventory_units,
+          cost: cost
+        }
+      end
+
+      def shipped_at
+        Time.zone.now if fulfillment_status == 'fulfilled'
+      end
+
+      def fulfillment_status
+        @data['Lineitem fulfillment status']
+      end
+
+      def shipping_method_name
+        @data['Shipping Line Title'] || super
+      end
+
+      def shipping_method
+        Spree::ShippingMethod.find_or_create_by(
+          name: shipping_method_name,
+          calculator: calculator,
+        ).tap do |sm|
+          sm.shipping_categories << shipping_category
+          sm.save!
+        end
+      end
+
+      def shipping_method_name
+        'SolidusImporter ShippingMethod'
+      end
+
+      def calculator
+        @calculator ||= Spree::Calculator::FlatRate.find_or_create_by(
+          preferences: { amount: 0 }
+        )
+      end
+
+      def shipping_category
+        Spree::ShippingCategory.find_or_create_by(
+          name: 'SolidusImporter ShippingCategory'
+        )
+      end
+
+      def stock_location
+        @stock_location ||= Spree::StockLocation.find_or_create_by(
+          name: 'SolidusImporter StockLocation'
+        )
+      end
+    end
+  end
+end

--- a/spec/features/solidus_importer/import_spec.rb
+++ b/spec/features/solidus_importer/import_spec.rb
@@ -158,5 +158,12 @@ RSpec.describe 'Import from CSV files' do # rubocop:disable RSpec/DescribeClass
       expect(imported_order.bill_address.state).to eq state
       expect(imported_order.bill_address.country).to eq state.country
     end
+
+    it 'imports order with ship address' do
+      import
+      expect(imported_order.ship_address).not_to be_blank
+      expect(imported_order.ship_address.state).to eq state
+      expect(imported_order.ship_address.country).to eq state.country
+    end
   end
 end

--- a/spec/features/solidus_importer/import_spec.rb
+++ b/spec/features/solidus_importer/import_spec.rb
@@ -152,6 +152,11 @@ RSpec.describe 'Import from CSV files' do # rubocop:disable RSpec/DescribeClass
       expect(Spree::LogEntry).to have_received(:create!).exactly(csv_file_rows).times
     end
 
+    it 'imports order with line items' do
+      import
+      expect(imported_order.line_items).not_to be_blank
+    end
+
     it 'imports an order with bill address' do
       import
       expect(imported_order.bill_address).not_to be_blank

--- a/spec/features/solidus_importer/import_spec.rb
+++ b/spec/features/solidus_importer/import_spec.rb
@@ -170,5 +170,10 @@ RSpec.describe 'Import from CSV files' do # rubocop:disable RSpec/DescribeClass
       expect(imported_order.ship_address.state).to eq state
       expect(imported_order.ship_address.country).to eq state.country
     end
+
+    it 'imports order with shipments' do
+      import
+      expect(imported_order.shipments).not_to be_blank
+    end
   end
 end

--- a/spec/features/solidus_importer/import_spec.rb
+++ b/spec/features/solidus_importer/import_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe 'Import from CSV files' do # rubocop:disable RSpec/DescribeClass
     let(:product) { create(:product) }
     let!(:state) { create(:state, abbr: 'ON', country_iso: 'CA') }
     let(:imported_order) { Spree::Order.first }
+    let(:tax_category) { product.tax_category }
 
     before do
       create(:store)
@@ -182,6 +183,20 @@ RSpec.describe 'Import from CSV files' do # rubocop:disable RSpec/DescribeClass
       expect(imported_order.payment_state).to eq 'paid'
       expect(imported_order.payments.first.state).to eq 'completed'
       expect(imported_order.payment_total).to eq imported_order.payments.first.amount
+    end
+
+    context 'when there is a promotion applicable to the order' do
+      let(:zone) { create(:zone, countries: [country]) }
+      let(:country) { state.country }
+
+      before do
+        create(:tax_rate, tax_categories: [tax_category], zone: zone)
+      end
+
+      it 'has no taxes by default' do
+        import
+        expect(imported_order.tax_total).to eq 0
+      end
     end
   end
 end

--- a/spec/features/solidus_importer/import_spec.rb
+++ b/spec/features/solidus_importer/import_spec.rb
@@ -175,5 +175,13 @@ RSpec.describe 'Import from CSV files' do # rubocop:disable RSpec/DescribeClass
       import
       expect(imported_order.shipments).not_to be_blank
     end
+
+    it 'imports the order with payments' do
+      import
+      expect(imported_order.payments).not_to be_empty
+      expect(imported_order.payment_state).to eq 'paid'
+      expect(imported_order.payments.first.state).to eq 'completed'
+      expect(imported_order.payment_total).to eq imported_order.payments.first.amount
+    end
   end
 end

--- a/spec/features/solidus_importer/import_spec.rb
+++ b/spec/features/solidus_importer/import_spec.rb
@@ -133,10 +133,19 @@ RSpec.describe 'Import from CSV files' do # rubocop:disable RSpec/DescribeClass
     let(:import_type) { :orders }
     let(:csv_file_rows) { 4 }
     let(:order_numbers) { ['#MA-1097', '#MA-1098'] }
-    let!(:store) { create(:store) }
+    let(:product) { create(:product) }
+
+    before do
+      create(:state, abbr: 'ON', country_iso: 'CA')
+      create(:store)
+      create(:shipping_method, name: 'Acme Shipping')
+      create(:variant, sku: 'a-123', product: product)
+      create(:variant, sku: 'a-456', product: product)
+      create(:variant, sku: 'b-001', product: product)
+    end
 
     it 'imports some orders' do
-      expect { import }.to change(Spree::Order, :count).by(2)
+      expect { import }.to change(Spree::Order, :count).from(0).to(2)
       expect(Spree::Order.where(number: order_numbers).count).to eq(2)
       expect(import.state).to eq('completed')
       expect(Spree::LogEntry).to have_received(:create!).exactly(csv_file_rows).times

--- a/spec/features/solidus_importer/import_spec.rb
+++ b/spec/features/solidus_importer/import_spec.rb
@@ -134,9 +134,10 @@ RSpec.describe 'Import from CSV files' do # rubocop:disable RSpec/DescribeClass
     let(:csv_file_rows) { 4 }
     let(:order_numbers) { ['#MA-1097', '#MA-1098'] }
     let(:product) { create(:product) }
+    let!(:state) { create(:state, abbr: 'ON', country_iso: 'CA') }
+    let(:imported_order) { Spree::Order.first }
 
     before do
-      create(:state, abbr: 'ON', country_iso: 'CA')
       create(:store)
       create(:shipping_method, name: 'Acme Shipping')
       create(:variant, sku: 'a-123', product: product)
@@ -149,6 +150,13 @@ RSpec.describe 'Import from CSV files' do # rubocop:disable RSpec/DescribeClass
       expect(Spree::Order.where(number: order_numbers).count).to eq(2)
       expect(import.state).to eq('completed')
       expect(Spree::LogEntry).to have_received(:create!).exactly(csv_file_rows).times
+    end
+
+    it 'imports an order with bill address' do
+      import
+      expect(imported_order.bill_address).not_to be_blank
+      expect(imported_order.bill_address.state).to eq state
+      expect(imported_order.bill_address.country).to eq state.country
     end
   end
 end

--- a/spec/lib/solidus_importer/base_importer_spec.rb
+++ b/spec/lib/solidus_importer/base_importer_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe SolidusImporter::BaseImporter do
 
   describe '#after_import' do
     it { is_expected.to respond_to(:after_import) }
+
+    context 'when ending contexts of rows is a success' do
+      subject { described_instance.after_import(context) }
+
+      let(:context) { { success: true } }
+
+      it 'returns a successful context' do
+        is_expected.to match(hash_including(success: true))
+      end
+    end
   end
 
   describe '#before_import' do

--- a/spec/lib/solidus_importer/order_importer_spec.rb
+++ b/spec/lib/solidus_importer/order_importer_spec.rb
@@ -28,19 +28,19 @@ RSpec.describe SolidusImporter::OrderImporter do
 
       before do
         described_instance.orders = orders
-        allow(Spree::Core::Importer::Order).to receive(:import)
+        allow(SolidusImporter::SpreeCoreImporterOrder).to receive(:import)
       end
 
       it 'calls Solidus order importer with those params' do
         expect(ending_context).to be_an_instance_of(Hash)
-        expect(Spree::Core::Importer::Order).to have_received(:import)
+        expect(SolidusImporter::SpreeCoreImporterOrder).to have_received(:import)
           .with(nil, hash_including(email: 'email@example.com'))
           .exactly(orders.size).times
       end
 
       context 'when something went wrong during import' do
         before do
-          allow(Spree::Core::Importer::Order).to receive(:import).and_raise(StandardError)
+          allow(SolidusImporter::SpreeCoreImporterOrder).to receive(:import).and_raise(StandardError)
         end
 
         it 'finish #after_import regardless of the error' do

--- a/spec/lib/solidus_importer/order_importer_spec.rb
+++ b/spec/lib/solidus_importer/order_importer_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusImporter::OrderImporter do
+  subject(:described_instance) { described_class.new(options) }
+
+  let(:options) { {} }
+
+  describe '#after_import' do
+    subject(:ending_context) { described_instance.after_import }
+
+    context 'when there are orders attributes' do
+      let(:orders) do
+        {
+          '#001' => {
+            number: '#001',
+            email: 'email@example.com'
+          },
+          '#002' => {
+            number: '#002',
+            email: 'email@example.com'
+          }
+        }
+      end
+
+      before do
+        described_instance.orders = orders
+        allow(Spree::Core::Importer::Order).to receive(:import)
+      end
+
+      it 'calls Solidus order importer with those params' do
+        expect(ending_context).to be_an_instance_of(Hash)
+        expect(Spree::Core::Importer::Order).to have_received(:import)
+          .with(nil, hash_including(email: 'email@example.com'))
+          .exactly(orders.size).times
+      end
+    end
+  end
+
+  describe '#before_import' do
+    it { is_expected.to respond_to(:before_import) }
+  end
+
+  describe '#processors' do
+    subject(:described_method) { described_instance.processors }
+
+    it { is_expected.to be_empty }
+  end
+end

--- a/spec/lib/solidus_importer/processors/bill_address_spec.rb
+++ b/spec/lib/solidus_importer/processors/bill_address_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusImporter::Processors::BillAddress do
+  describe '#call' do
+    subject(:described_method) { described_class.call(context) }
+
+    let(:context) do
+      { data: data }
+    end
+    let(:data) do
+      {
+        'Billing First Name' => 'John',
+        'Billing Last Name' => 'Doe',
+        'Billing Address1' => 'An address',
+        'Billing Address2' => '',
+        'Billing City' => 'A Beautyful city',
+        'Billing Company' => 'A Company',
+        'Billing Zip' => '00000',
+        'Billing Phone' => '555-123123123',
+        'Billing Country Code' => 'US',
+        'Billing Province Code' => 'NM'
+      }
+    end
+
+    it 'put bill_address_attributes into order data' do
+      described_method
+      expect(context).to have_key(:order)
+      expect(context[:order][:bill_address_attributes]).not_to be_empty
+    end
+  end
+end

--- a/spec/lib/solidus_importer/processors/line_item_spec.rb
+++ b/spec/lib/solidus_importer/processors/line_item_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusImporter::Processors::LineItem do
+  describe '#call' do
+    subject(:described_method) { described_class.call(context) }
+
+    let(:context) do
+      { data: data }
+    end
+    let(:data) do
+      { 'Lineitem sku' => 'a-sku' }
+    end
+
+    it 'put line_items_attributes into order data' do
+      described_method
+      expect(context).to have_key(:order)
+      expect(context[:order][:line_items_attributes]).not_to be_empty
+    end
+  end
+end

--- a/spec/lib/solidus_importer/processors/order_spec.rb
+++ b/spec/lib/solidus_importer/processors/order_spec.rb
@@ -23,33 +23,12 @@ RSpec.describe SolidusImporter::Processors::Order do
         { data: data }
       end
       let(:data) { build(:solidus_importer_row_order, :with_import).data }
-      let(:result) { context.merge(order: Spree::Order.last) }
 
       before { allow(Spree::Store).to receive(:default).and_return(build_stubbed(:store)) }
 
       it 'creates a new order' do
-        expect { described_method }.to change { Spree::Order.count }.by(1)
-        expect(described_method).to eq(result)
-      end
-
-      context 'with an existing valid order' do
-        let!(:order) { create(:order, number: data['Name'], email: data['Email']) }
-
-        it 'updates the order' do
-          expect { described_method }.not_to(change{ Spree::Order.count })
-          expect(described_method).to eq(result)
-          expect(order.reload.email).to eq('an_email@example.com')
-        end
-      end
-
-      context 'with an existing invalid order' do
-        let!(:order) { create(:order, number: data['Name'], email: data['Email']) }
-
-        before { order.update_column(:state, 'an invalid state') }
-
-        it 'raises an exception' do
-          expect { described_method }.to raise_error(ActiveRecord::RecordInvalid, /State is invalid/)
-        end
+        described_method
+        expect(context[:order]).to match(hash_including(number: 'R123456789'))
       end
     end
   end

--- a/spec/lib/solidus_importer/processors/payment_spec.rb
+++ b/spec/lib/solidus_importer/processors/payment_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusImporter::Processors::Payment do
+  describe '#call' do
+    subject(:described_method) { described_class.call(context) }
+
+    let(:context) do
+      { data: data }
+    end
+    let(:data) do
+      {
+        'Financial Status' => 'paid',
+        'Lineitem price' => '10.5',
+        'Lineitem quantity' => '2'
+      }
+    end
+    let(:expected_params) do
+      [{ payment_method: payment_method_name, amount: amount }]
+    end
+    let(:payment_method_name) { 'SolidusImporter PaymentMethod' }
+    let(:amount) { 21.0 }
+
+    it 'put payments_attributes into order data' do
+      described_method
+      expect(context).to have_key(:order)
+      expect(context[:order][:payments_attributes]).to eq expected_params
+    end
+  end
+end

--- a/spec/lib/solidus_importer/processors/ship_address_spec.rb
+++ b/spec/lib/solidus_importer/processors/ship_address_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusImporter::Processors::ShipAddress do
+  describe '#call' do
+    subject(:described_method) { described_class.call(context) }
+
+    let(:context) do
+      { data: data }
+    end
+    let(:data) do
+      {
+        'Shipping First Name' => 'John',
+        'Shipping Last Name' => 'Doe',
+        'Shipping Address1' => 'An address',
+        'Shipping Address2' => '',
+        'Shipping City' => 'A Beautyful city',
+        'Shipping Company' => 'A Company',
+        'Shipping Zip' => '00000',
+        'Shipping Phone' => '555-123123123',
+        'Shipping Country Code' => 'US',
+        'Shipping Province Code' => 'NM'
+      }
+    end
+
+    it 'put ship_address_attributes into order data' do
+      described_method
+      expect(context).to have_key(:order)
+      expect(context[:order][:ship_address_attributes]).not_to be_empty
+    end
+  end
+end

--- a/spec/lib/solidus_importer/processors/shipment_spec.rb
+++ b/spec/lib/solidus_importer/processors/shipment_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusImporter::Processors::Shipment do
+  describe '#call' do
+    subject(:described_method) { described_class.call(context) }
+
+    let(:context) do
+      { data: data }
+    end
+    let(:data) do
+      { 'Shipping Line Title' => 'ACME Shipping' }
+    end
+
+    it 'put shipments_attributes into order data' do
+      described_method
+      expect(context).to have_key(:order)
+      expect(context[:order][:shipments_attributes]).not_to be_empty
+    end
+  end
+end


### PR DESCRIPTION
The approach used to generate entities whenever they're encountered during CSV row parsing works well with Customers and Products models, but has some downside when importing orders. This is because the models involved have more constraints and validations on models and associated models, and you could end up having entities in inconsistent state.

For this reason we've decided to take advantage of the [Solidus order importer](https://github.com/solidusio/solidus/blob/master/core/lib/spree/core/importer/order.rb). Order's processors won't create entities anymore, but are responsible to build the data structure needed by the aforementioned importer, which actually creates orders. The importer is invoked after the whole CSV is parsed, in the `#after_import` callback defined in a custom `OrderImporter` which extend the `Base` importer used by other types (customers, products).