### PR TITLE
OptionTypes loaded from DB instead of off product

### DIFF
--- a/lib/solidus_importer/processors/option_types.rb
+++ b/lib/solidus_importer/processors/option_types.rb
@@ -15,13 +15,11 @@ module SolidusImporter
 
       def process_option_types(product)
         option_type_names.each_with_index.map do |name, i|
-          option_type = product.option_types.find_or_initialize_by(
-            name: name
-          )
-          option_type.presentation = name
-          option_type.name = name.downcase
+          option_type = Spree::OptionType.find_or_initialize_by(name: name.downcase)
+          option_type.presentation ||= name
           option_type.position = i + 1
           option_type.save
+          product.option_types << option_type unless product.option_types.include?(option_type)
         end
       end
 

--- a/spec/lib/solidus_importer/processors/option_types_spec.rb
+++ b/spec/lib/solidus_importer/processors/option_types_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe SolidusImporter::Processors::OptionTypes do
 
     let(:context) { { data: data, product: product } }
     let(:product) { create :base_product }
-    let(:color) { create :option_type, presentation: 'The color', name: 'Color' }
-    let(:size) { create :option_type, presentation: 'The size', name: 'Size' }
+    let(:color) { create :option_type, presentation: 'The color', name: 'color' }
+    let(:size) { create :option_type, presentation: 'The size', name: 'size' }
     let(:data) do
       {
         'Option1 Name' => 'Size',

--- a/spec/lib/solidus_importer/processors/option_types_spec.rb
+++ b/spec/lib/solidus_importer/processors/option_types_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe SolidusImporter::Processors::OptionTypes do
     end
 
     context 'when "Option(1,2,3) Name" are present' do
+      context 'when product does not have option types' do
+        before do
+          color
+          size
+        end
+
+        xit 'does not create option type records' do
+          expect { described_method }.not_to change(Spree::OptionType, :count)
+        end
+      end
+
       context 'when product already has option types' do
         before { product.option_types << color << size }
 

--- a/spec/lib/solidus_importer/processors/option_types_spec.rb
+++ b/spec/lib/solidus_importer/processors/option_types_spec.rb
@@ -24,8 +24,12 @@ RSpec.describe SolidusImporter::Processors::OptionTypes do
           size
         end
 
-        xit 'does not create option type records' do
+        it 'does not create option type records' do
           expect { described_method }.not_to change(Spree::OptionType, :count)
+        end
+
+        it 'does not overwrite the option_type presentation' do
+          expect { described_method }.not_to change { size.reload.presentation }
         end
       end
 


### PR DESCRIPTION
While I was importing some products into a store I was working on I noticed that I seemed to be getting duplicate Spree::OptionType values in the database, and I believe it was coming from the OptionType import here. I was able to replicate the issue by first saving the option type in the specs to the database and ensure they weren't on the product.

I think this is a use case that could happen to other people too, where the OptionType already exists in the DB without it being on the product. I think this covers the existing behaviour fairly well, and ensures we don't get any duplicate records.

If there's a quicker way to link the record created by the initialize on the product from the original code to the DB let me know.