### PR TITLE
Do not add taxon if it's on the product

### DIFF
--- a/lib/solidus_importer/processors/taxon.rb
+++ b/lib/solidus_importer/processors/taxon.rb
@@ -24,13 +24,17 @@ module SolidusImporter
       end
 
       def process_taxons_type
-        product.taxons << prepare_taxon(type, options[:type_taxonomy])
+        add_taxon(prepare_taxon(type, options[:type_taxonomy]))
       end
 
       def process_taxons_tags
         tags.map do |tag|
-          product.taxons << prepare_taxon(tag, options[:tags_taxonomy])
+          add_taxon(prepare_taxon(tag, options[:tags_taxonomy]))
         end
+      end
+
+      def add_taxon(taxon)
+        product.taxons << taxon unless product.taxons.include?(taxon)
       end
 
       def prepare_taxon(name, taxonomy)

--- a/spec/lib/solidus_importer/processors/taxon_spec.rb
+++ b/spec/lib/solidus_importer/processors/taxon_spec.rb
@@ -29,5 +29,18 @@ RSpec.describe SolidusImporter::Processors::Taxon do
       expect(type_taxonomy).to be_present
       expect(tags_taxonomy).to be_present
     end
+
+    context 'taxon already exists on product' do
+      let(:tags_taxonomy) { create(:taxonomy, name: 'Tags') }
+      let!(:taxon) { create(:taxon, name: 'Tag1', taxonomy: tags_taxonomy) }
+
+      before do
+        product.taxons << taxon
+      end
+
+      it 'does not raise a Validation error' do
+        expect { described_method }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
When processing rows that are variants, this code will get called for a product that has been previously processed by the master variant row. In this case, the taxons will already exist on the product and be in the database. This causes a validation error to be raised because the taxon cannot be added twice to the product. We can get around this by just checking if the taxon that will be added is already there.