### PR TITLE
Skip empty option values

### DIFF
--- a/lib/solidus_importer/processors/option_values.rb
+++ b/lib/solidus_importer/processors/option_values.rb
@@ -17,6 +17,8 @@ module SolidusImporter
 
       def process_option_values
         option_value_names.each_with_index do |name, i|
+          next if name.empty?
+
           option_value = Spree::OptionValue.find_or_initialize_by(
             option_type: option_type(i),
             name: name

--- a/spec/lib/solidus_importer/processors/option_values_spec.rb
+++ b/spec/lib/solidus_importer/processors/option_values_spec.rb
@@ -39,5 +39,18 @@ RSpec.describe SolidusImporter::Processors::OptionValues do
         expect(l.option_type).to eq size
       end
     end
+
+    context 'when an Option has an empty value' do
+      let(:data) do
+        {
+          'Option1 Name' => 'Size',
+          'Option1 Value' => ''
+        }
+      end
+
+      it 'does not create option values for variant in row' do
+        expect { described_method }.not_to change(variant.option_values, :count)
+      end
+    end
   end
 end


### PR DESCRIPTION
The Shopify CSV format specifies the OptionValue column be empty for the first row of a product with multiple variants. I believe this row becomes the master variant. I noticed when I was following the Shopify documentation that the first row for products was failing because it would attempt to make an option value with the empty string, which then causes a validation error to be thrown.

Instead we can just skip through any empty values.