### PR TITLE
Fix option types and values processors

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -9,3 +9,5 @@ Spree::Backend::Config.configure do |config|
     url: :admin_solidus_importer_imports_path
   )
 end
+
+MIME::Types.add(MIME::Type.new(["application/csv", "csv"]), true)

--- a/lib/solidus_importer/processors/option_types.rb
+++ b/lib/solidus_importer/processors/option_types.rb
@@ -15,11 +15,14 @@ module SolidusImporter
 
       def process_option_types(product)
         option_type_names.each_with_index.map do |name, i|
-          option_type = Spree::OptionType.find_or_initialize_by(name: name.downcase)
+          option_type = Spree::OptionType.find_or_initialize_by(
+            name: name.parameterize
+          )
           option_type.presentation ||= name
           option_type.position = i + 1
-          option_type.save
+          option_type.save!
           product.option_types << option_type unless product.option_types.include?(option_type)
+          option_type
         end
       end
 

--- a/lib/solidus_importer/processors/option_values.rb
+++ b/lib/solidus_importer/processors/option_values.rb
@@ -21,10 +21,12 @@ module SolidusImporter
 
           option_value = Spree::OptionValue.find_or_initialize_by(
             option_type: option_type(i),
-            name: name
+            name: name.parameterize
           )
           option_value.presentation = name
+          option_value.save!
           variant.option_values << option_value
+          variant.save!
         end
       end
 

--- a/spec/lib/solidus_importer/processors/option_values_spec.rb
+++ b/spec/lib/solidus_importer/processors/option_values_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe SolidusImporter::Processors::OptionValues do
       it 'create option values for variant in row' do
         expect { described_method }.to change(variant.option_values, :count).from(0).to(2)
         expect(variant.option_values.first.presentation).to eq 'L'
-        expect(variant.option_values.first.name).to eq 'L'
+        expect(variant.option_values.first.name).to eq 'l'
         expect(variant.option_values.last.presentation).to eq 'Black'
-        expect(variant.option_values.last.name).to eq 'Black'
+        expect(variant.option_values.last.name).to eq 'black'
       end
 
       it 'creates "Black" option value for related "Color" option type' do


### PR DESCRIPTION
Thanks for this extension. 🙏  

While working on a client, I've noticed some small bugs that I've squashed with this PR.

I've also tried to add a little bit of consistency between the processors.

Paperclip seems to have a small bug in handling the CSV MIME type. I've added a fix for that.

I hope that this can be helpful. Let me know what do you think.