### PR TITLE
Add configurable row-level exception handler

### DIFF
--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -40,6 +40,17 @@ module SolidusImporter
     def available_types
       solidus_importer.keys
     end
+
+    # Solidus's preferences assume that if the default value is a Proc/lambda
+    # that it should be called to return the actual default value. In order to
+    # set a default value that is itself a Proc, you must wrap it in another
+    # Proc. This only applies to the default value and this preference can be
+    # set normally, by assigning the Proc directly.
+    #
+    # Additionally, some versions of Solidus will pass in the version as an
+    # argument. Using a lambda will verify that the correct number of arguments
+    # are passed, whereas using a plain Proc won't.
+    preference :row_exception_handler, :callable, default: proc { ->(exception, context) {} }
   end
 
   class << self

--- a/lib/solidus_importer/process_row.rb
+++ b/lib/solidus_importer/process_row.rb
@@ -17,6 +17,7 @@ module SolidusImporter
         processor.call(context)
       rescue StandardError => e
         context.merge!(success: false, messages: e.message) # rubocop:disable Performance/RedundantMerge
+        SolidusImporter::Config.row_exception_handler.call(e, context)
         break
       end
 

--- a/spec/lib/solidus_importer/process_row_spec.rb
+++ b/spec/lib/solidus_importer/process_row_spec.rb
@@ -21,4 +21,40 @@ RSpec.describe SolidusImporter::ProcessRow do
       it { expect(described_instance).to be_instance_of(described_class) }
     end
   end
+
+  describe "#process" do
+    subject(:process) { described_instance.process(context) }
+
+    let(:context) { {} }
+
+    let(:import) { create :solidus_importer_import_customers }
+    let(:row) { create :solidus_importer_row_customer, import: import }
+
+    context 'when a processor raises an exception' do
+      let(:importer) {
+        instance_double(
+          SolidusImporter::BaseImporter,
+          processors: [processor],
+          handle_row_import: nil
+        )
+      }
+      let(:processor) { SolidusImporter::Processors::Base }
+
+      before do
+        allow(processor).to receive(:call) { raise "Something bad happened" }
+      end
+
+      it "calls the configured exception handler" do
+        # rubocop:disable RSpec/MessageSpies
+        expect(SolidusImporter::Config.row_exception_handler).to receive(:call) do |exception, context|
+          expect(exception.message).to eq "Something bad happened"
+          expect(context[:importer]).to eq importer
+          expect(context[:row_id]).to eq row.id
+        end
+        # rubocop:enable RSpec/MessageSpies
+
+        process
+      end
+    end
+  end
 end


### PR DESCRIPTION
This add a new "row_exception_handler" preference which can be set to anything callable and is invoked when exceptions happen during row processing after the critical step of marking the context as unsuccessful and recording the message.

This can be used to report exceptions and the associated context to an error reporting services, something like:

```ruby
SolidusImporter::Config.row_exception_handler = -> (e, context) {
  Sentry.capture_exception(e)
}
```

This addresses #50.