### PR TITLE
Import multiple Line items for the Orders

### DIFF
--- a/lib/solidus_importer/order_importer.rb
+++ b/lib/solidus_importer/order_importer.rb
@@ -19,8 +19,16 @@ module SolidusImporter
       orders[number] ||= {}
 
       order_params = context[:order].to_h.reject { |_k, v| v.blank? }
-      payments_attributes = order_params[:payments_attributes]
+
+      payments_attributes = order_params.delete(:payments_attributes)
+      line_items_attributes = order_params.delete(:line_items_attributes)
+
       orders[number][:payments_attributes] ||= []
+      orders[number][:line_items_attributes] ||= {}
+
+      index = orders[number][:line_items_attributes].size
+      orders[number][:line_items_attributes][index] = line_items_attributes if line_items_attributes.present?
+
       orders[number][:payments_attributes] << payments_attributes if payments_attributes.present?
       orders[number].merge!(order_params)
     end

--- a/lib/solidus_importer/processors/line_item.rb
+++ b/lib/solidus_importer/processors/line_item.rb
@@ -9,12 +9,7 @@ module SolidusImporter
         return if @data['Lineitem sku'].blank?
 
         order = context.fetch(:order, {})
-
-        order[:line_items_attributes] ||= {}
-
-        index = order[:line_items_attributes].size
-
-        order[:line_items_attributes][index] = line_items_attributes
+        order[:line_items_attributes] = line_items_attributes
 
         context.merge!(order: order)
       end

--- a/lib/solidus_importer/processors/payment.rb
+++ b/lib/solidus_importer/processors/payment.rb
@@ -14,8 +14,7 @@ module SolidusImporter
 
         self.order = context.fetch(:order, {})
 
-        order[:payments_attributes] ||= []
-        order[:payments_attributes] << payment_attributes
+        order[:payments_attributes] = payment_attributes
 
         context.merge!(order: order)
       end

--- a/lib/solidus_importer/processors/shipment.rb
+++ b/lib/solidus_importer/processors/shipment.rb
@@ -22,13 +22,15 @@ module SolidusImporter
       end
 
       def inventory_units
-        line_items_attributes.map do |_, line_item|
-          { sku: line_item[:sku] }
-        end
+        sku = line_items_attributes[:sku]
+
+        return [] if sku.blank?
+
+        [{ sku: sku }]
       end
 
       def line_items_attributes
-        order.fetch(:line_items_attributes, [])
+        order.fetch(:line_items_attributes, {})
       end
 
       def shipments_attributes

--- a/spec/features/solidus_importer/import_spec.rb
+++ b/spec/features/solidus_importer/import_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe 'Import from CSV files' do
     let(:order_numbers) { ['#MA-1097', '#MA-1098'] }
     let(:product) { create(:product) }
     let!(:state) { create(:state, abbr: 'ON', country_iso: 'CA') }
-    let(:imported_order) { Spree::Order.first }
+    let(:imported_order) { Spree::Order.find_by(number: '#MA-1097') }
     let(:tax_category) { product.tax_category }
 
     before do
@@ -165,13 +165,14 @@ RSpec.describe 'Import from CSV files' do
     it 'imports some orders' do
       expect { import }.to change(Spree::Order, :count).from(0).to(2)
       expect(Spree::Order.where(number: order_numbers).count).to eq(2)
+
       expect(import.state).to eq('completed')
       expect(Spree::LogEntry).to have_received(:create!).exactly(csv_file_rows).times
     end
 
     it 'imports order with line items' do
       import
-      expect(imported_order.line_items).not_to be_blank
+      expect(imported_order.line_items.count).to eq 2
     end
 
     it 'imports an order with bill address' do
@@ -198,7 +199,7 @@ RSpec.describe 'Import from CSV files' do
       expect(imported_order.payments).not_to be_empty
       expect(imported_order.payment_state).to eq 'paid'
       expect(imported_order.payments.first.state).to eq 'completed'
-      expect(imported_order.payment_total).to eq imported_order.payments.first.amount
+      expect(imported_order.payment_total).to eq imported_order.payments.sum(&:amount)
     end
 
     context 'when there is a promotion applicable to the order' do

--- a/spec/lib/solidus_importer/processors/payment_spec.rb
+++ b/spec/lib/solidus_importer/processors/payment_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SolidusImporter::Processors::Payment do
       }
     end
     let(:expected_params) do
-      [{ payment_method: payment_method_name, amount: amount }]
+      { payment_method: payment_method_name, amount: amount }
     end
     let(:payment_method_name) { 'SolidusImporter PaymentMethod' }
     let(:amount) { 21.0 }


### PR DESCRIPTION
Ref. #62 

- fix how processors store attributes; this way the related attributes
  won't be deleted between row processing.
- improve expectations to check multiple line items have been imported.