### PR TITLE
Add ProductStore processor

### DIFF
--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -27,6 +27,7 @@ module SolidusImporter
         importer: SolidusImporter::BaseImporter,
         processors: [
           SolidusImporter::Processors::Product,
+          SolidusImporter::Processors::ProductStore,
           SolidusImporter::Processors::Variant,
           SolidusImporter::Processors::OptionTypes,
           SolidusImporter::Processors::OptionValues,

--- a/lib/solidus_importer/processors/product_store.rb
+++ b/lib/solidus_importer/processors/product_store.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusImporter
+  module Processors
+    class ProductStore
+      def call(context)
+        product = context.fetch(:product) || raise(ArgumentError, 'missing :product in context')
+        store = Spree::Store.default
+        product.update!(store: store)
+
+        context.merge!(store: store)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Processor is added to the Products pipeline so that Products get associated with the default Spree::Store.

A possible improvement would be allowing users to specify the Store to import to on the import screen