### PR TITLE
Surface after_import errors

### DIFF
--- a/lib/solidus_importer/order_importer.rb
+++ b/lib/solidus_importer/order_importer.rb
@@ -29,7 +29,9 @@ module SolidusImporter
       orders.each do |_, params|
         user = params.delete(:user)
         SolidusImporter::SpreeCoreImporterOrder.import(user, params)
-      rescue StandardError
+      rescue StandardError => e
+        context[:messages] ||= []
+        context[:messages] << e.message
         context[:success] = false
       end
 

--- a/lib/solidus_importer/process_import.rb
+++ b/lib/solidus_importer/process_import.rb
@@ -30,7 +30,10 @@ module SolidusImporter
         state = @import.state
         state = :completed if rows.zero?
         state = :failed if ending_context[:success] == false
-        @import.update(state: state)
+
+        messages = ending_context[:messages].try(:join, ', ')
+
+        @import.update(state: state, messages: messages)
       end
       @import
     end

--- a/spec/lib/solidus_importer/order_importer_spec.rb
+++ b/spec/lib/solidus_importer/order_importer_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe SolidusImporter::OrderImporter do
 
       context 'when something went wrong during import' do
         before do
-          allow(SolidusImporter::SpreeCoreImporterOrder).to receive(:import).and_raise(StandardError)
+          allow(SolidusImporter::SpreeCoreImporterOrder).to receive(:import).and_raise(StandardError.new('message'))
         end
 
-        it 'finish #after_import regardless of the error' do
+        it 'finishes #after_import regardless of the error and surfaces the error' do
           expect { ending_context }.not_to raise_error
-          expect(ending_context).to match(hash_including(success: false))
+          expect(ending_context).to match(hash_including(success: false, messages: ['message', 'message']))
         end
       end
     end


### PR DESCRIPTION
Currently, if the `after_import` method of the importer generates an error, the ProcessImport will update the import state accordingly. However, there's no way to see the reason why the process failed, which is relevant where the `after_import` does most of the persisting work, ie on `OrderImporter`.

This change simply joins all error messages found during the Order persistence and tweaks ProcessImport so that it updates the final `SolidusImporter::Import` message accordingly