### PR TITLE
Process taxons if "Tags" or "Type" are empty

### DIFF
--- a/lib/solidus_importer/processors/taxon.rb
+++ b/lib/solidus_importer/processors/taxon.rb
@@ -24,6 +24,8 @@ module SolidusImporter
       end
 
       def process_taxons_type
+        return unless type
+
         add_taxon(prepare_taxon(type, options[:type_taxonomy]))
       end
 
@@ -45,11 +47,13 @@ module SolidusImporter
       end
 
       def tags
+        return [] unless @data['Tags'].presence
+
         @data['Tags'].split(',').map(&:strip)
       end
 
       def type
-        @data['Type']
+        @data['Type'].presence
       end
     end
   end

--- a/spec/lib/solidus_importer/processors/taxon_spec.rb
+++ b/spec/lib/solidus_importer/processors/taxon_spec.rb
@@ -32,6 +32,36 @@ RSpec.describe SolidusImporter::Processors::Taxon do
       expect(tags_taxonomy).to be_present
     end
 
+    context "when data does not include type or tags" do
+      let(:data) {
+        build(:solidus_importer_row_product, :with_import).data
+      }
+
+      it "completes successfully" do
+        expect { described_method }.not_to raise_error
+      end
+    end
+
+    context "when data does not include tags" do
+      let(:data) {
+        build(:solidus_importer_row_product, :with_import, :with_type).data
+      }
+
+      it "completes successfully" do
+        expect { described_method }.not_to raise_error
+      end
+    end
+
+    context "when data does not include type" do
+      let(:data) {
+        build(:solidus_importer_row_product, :with_import, :with_tags).data
+      }
+
+      it "completes successfully" do
+        expect { described_method }.not_to raise_error
+      end
+    end
+
     context 'when taxon already exists on product' do
       let(:tags_taxonomy) { create(:taxonomy, name: 'Tags') }
       let(:taxon) { create(:taxon, name: 'Tag1', taxonomy: tags_taxonomy) }


### PR DESCRIPTION
Before this commit, an empty "Tags" or "Type" cell in a CSV would cause this processor to fail.

I believe it's reasonable to assume that some products may not include tags on import. And, while I'd prefer all products be imported with a "Type" personally, I don't this this is should be a hard requirement that makes rows fail in a product import.