### PR TITLE
Don't add an option value if already added 

### DIFF
--- a/lib/solidus_importer/processors/option_values.rb
+++ b/lib/solidus_importer/processors/option_values.rb
@@ -25,7 +25,7 @@ module SolidusImporter
           )
           option_value.presentation = name
           option_value.save!
-          variant.option_values << option_value
+          variant.option_values << option_value unless variant.option_values.include?(option_value)
           variant.save!
         end
       end

--- a/lib/solidus_importer/processors/variant.rb
+++ b/lib/solidus_importer/processors/variant.rb
@@ -28,8 +28,15 @@ module SolidusImporter
           variant.weight = @data['Variant Weight'] unless @data['Variant Weight'].nil?
           variant.price = @data['Variant Price'] if @data['Variant Price'].present?
 
-          # Save the product
+          # Save the variant
           variant.save!
+
+          # update the inventory using the default location
+          # TODO: upate to use multiple stock locations depending on the import file row
+          if @data['Variant Inventory Qty'].present?
+            stock_item = Spree::StockLocation.order_default.first.stock_item_or_create(variant)
+            stock_item.adjust_count_on_hand(@data['Variant Inventory Qty'].to_i) unless stock_item.nil?
+          end
         end
       end
 
@@ -45,6 +52,10 @@ module SolidusImporter
       def generate_sku
         variant_part = @data['Option1 Value'].parameterize
         "#{product.slug}-#{variant_part}"
+      end
+
+      def default_stock_location
+        Spree::StockLocation.order_default.first.id
       end
     end
   end

--- a/lib/solidus_importer/testing_support/factories/solidus_importer_rows_factory.rb
+++ b/lib/solidus_importer/testing_support/factories/solidus_importer_rows_factory.rb
@@ -69,7 +69,8 @@ FactoryBot.define do
         'Handle' => 'a-product-slug-2',
         'Variant SKU' => 'a-variant-sku',
         'Variant Weight' => 20.0,
-        'Variant Price' => 60.5
+        'Variant Price' => 60.5,
+        'Variant Inventory Qty' => 5
       }
     end
 

--- a/spec/lib/solidus_importer/processors/variant_spec.rb
+++ b/spec/lib/solidus_importer/processors/variant_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe SolidusImporter::Processors::Variant do
           expect(described_method).to eq(result)
           expect(product.variants.first.weight).to eq 20.0
           expect(product.variants.first.price).to eq 60.5
+          expect(product.variants.first.total_on_hand).to eq 5
         end
       end
 


### PR DESCRIPTION
When using multiple images per variant we have to repeat the Options for that variant to identify the variant on each line of that variant where we specify a new variant image. What happens in this case is that an option is added multiple times (as many times as images for that variant). This PR checks if the option is already included.

It lacks a test for this but am not sure how to write one (described_method creates a new variant each time).