### PR TITLE
Import inventory quantities for variants

### DIFF
--- a/lib/solidus_importer/processors/variant.rb
+++ b/lib/solidus_importer/processors/variant.rb
@@ -28,8 +28,16 @@ module SolidusImporter
           variant.weight = @data['Variant Weight'] unless @data['Variant Weight'].nil?
           variant.price = @data['Variant Price'] if @data['Variant Price'].present?
 
-          # Save the product
+          # Save the variant
           variant.save!
+
+          # update the inventory using the default location
+          # if no stock locations are defined it won't do anything
+          # TODO: upate to use multiple stock locations depending on the import file row
+          if @data['Variant Inventory Qty'].present?
+            stock_item = Spree::StockLocation.order_default.first&.stock_item_or_create(variant)
+            stock_item&.adjust_count_on_hand(@data['Variant Inventory Qty'].to_i)
+          end
         end
       end
 

--- a/lib/solidus_importer/testing_support/factories/solidus_importer_rows_factory.rb
+++ b/lib/solidus_importer/testing_support/factories/solidus_importer_rows_factory.rb
@@ -69,7 +69,8 @@ FactoryBot.define do
         'Handle' => 'a-product-slug-2',
         'Variant SKU' => 'a-variant-sku',
         'Variant Weight' => 20.0,
-        'Variant Price' => 60.5
+        'Variant Price' => 60.5,
+        'Variant Inventory Qty' => 5
       }
     end
 

--- a/spec/lib/solidus_importer/processors/variant_spec.rb
+++ b/spec/lib/solidus_importer/processors/variant_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe SolidusImporter::Processors::Variant do
           expect(described_method).to eq(result)
           expect(product.variants.first.weight).to eq 20.0
           expect(product.variants.first.price).to eq 60.5
+          expect(product.variants.first.total_on_hand).to eq 5
         end
       end
 


### PR DESCRIPTION
This fix takes into account the quantities specified on variant rows
and imports them on the default location. If multiple stock locations
are used we'll need a convention in the import file to specify those
locations. This change does not deal with that situation.