### PR TITLE
Use Paperclip to read the Paperclip attachments

### DIFF
--- a/lib/solidus_importer/process_import.rb
+++ b/lib/solidus_importer/process_import.rb
@@ -51,7 +51,7 @@ module SolidusImporter
 
     def scan
       data = CSV.parse(
-        Paperclip.io_adapters.for(@import.file).read,
+        Paperclip.io_adapters.for(@import.file).read.force_encoding(Encoding::UTF_8),
         headers: true,
         encoding: 'UTF-8',
         header_converters: ->(h) { h.strip }

--- a/lib/solidus_importer/process_import.rb
+++ b/lib/solidus_importer/process_import.rb
@@ -51,7 +51,7 @@ module SolidusImporter
 
     def scan
       data = CSV.parse(
-        File.read(@import.file.path),
+        Paperclip.io_adapters.for(@import.file).read,
         headers: true,
         encoding: 'UTF-8',
         header_converters: ->(h) { h.strip }


### PR DESCRIPTION
We can't rely on the attachment path to be something we can just
`File.read` because it may not be a local file which can be opened.

Instead we can rely on Paperclip to give us an IO adapter which
is capable of reading an attachment independent from the backend.