### PR TITLE
Display successful row count in index

### DIFF
--- a/app/views/spree/admin/solidus_importer/imports/index.html.erb
+++ b/app/views/spree/admin/solidus_importer/imports/index.html.erb
@@ -49,7 +49,8 @@
           <th><%= sort_link @search, :id, t('spree.id') %></th>
           <th><%= sort_link @search, :import_type, t('spree.type') %></th>
           <th><%= sort_link @search, :state, t('spree.state') %></th>
-          <th><%= t('spree.solidus_importer.import_rows') %></th>
+          <th><%= t('spree.solidus_importer.successful_rows') %></th>
+          <th><%= t('spree.solidus_importer.total_rows') %></th>
           <th><%= sort_link @search, :updated_at, t('spree.solidus_importer.updated_at') %></th>
           <th class="actions"></th>
         </tr>
@@ -61,7 +62,8 @@
             <td><%= link_to import.id.to_s, link_details %></td>
             <td><%= import.import_type %></td>
             <td class="solidus_importer state-<%= import.state %>"><%= import.state %></td>
-            <th><%= import.rows.count %></th>
+            <td> <%= "#{import.rows.where(state: "completed").count}" %></td>
+            <td><%= import.rows.count %></td>
             <td><%= l(import.updated_at) %></td>
             <td><%= link_to 'Details', link_details, class: 'fa fa-eye icon_link', 'data-action': 'view' %></td>
           </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,9 +8,11 @@ en:
       import_rows: Import rows
       log_entry: Log information
       messages: Messages
+      successful_rows: Successful rows
       target_entity: Target entity
       title: &solidus_importer_title
         Importer
+      total_rows: Total rows
       updated_at: Updated at
       updated_at_from: 'Updated at: start date'
       updated_at_to: 'Updated at: end date'


### PR DESCRIPTION
It is difficult to determine the relative success of an import, without clicking
through to the edit/show page, since even one row failure will set the state.

This should provide admin users a bit better feedback on their imports.

Spec Update:

| Description | Screenshot |
| ------------- | ------------- |
| Just after creation | ![Screen Shot 2022-01-31 at 3 44 38 PM](https://user-images.githubusercontent.com/6599070/151891509-c8437db7-43f3-43d3-b9d6-0dc9d988609e.png) |
| Processing in progress | ![Screen Shot 2022-01-31 at 3 44 46 PM](https://user-images.githubusercontent.com/6599070/151891533-254028f2-d6b2-42dd-b394-fe9340136a68.png) |
| After completion | ![Screen Shot 2022-01-31 at 3 44 55 PM](https://user-images.githubusercontent.com/6599070/151891541-06a6a66d-e35b-4468-95ec-9d1f830f49bc.png)  |