### PR TITLE
Relax Ruby version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Add solidus_importer to your Gemfile:
 gem 'solidus_importer'
 ```
 
+Instead of a stable build, if you want to use the bleeding edge version, use this line:
+
+```ruby
+gem 'solidus_importer', github: 'solidusio-contrib/solidus_importer'
+```
+
 Bundle your dependencies and run the installation generator:
 
 ```shell

--- a/examples/csvs/products.csv
+++ b/examples/csvs/products.csv
@@ -1,4 +1,4 @@
-Handle,Title,Published,Variant SKU,Variant Weight,Variant Price,Option1 Value,Option1 Name,Option2 Name,Option3 Name,Option2 Value,Option3 Value,Image Src,Alt Text,Variant Image
+Handle,Title,Published,Variant SKU,Variant Weight,Variant Price,Option1 Value,Option1 Name,Option2 Name,Option3 Name,Option2 Value,Option3 Value,Image Src,Image Alt Text,Variant Image
 my-sample-product,Sample Product,true,,,,Default Title,,,,,,https://github.com/solidusio/solidus/raw/master/sample/db/samples/images/ruby_hoodie.jpg,Cool Image,
 my-sample-product,,true,my-sample-product-1,10,5,Black,color,weight,size,50,m,,,https://github.com/solidusio/solidus/raw/master/sample/db/samples/images/solidus_tshirt_back_black.png
 my-sample-product,,true,my-sample-product-2,10,5,Blue,color,weight,size,50,m,,,https://github.com/solidusio/solidus/raw/master/sample/db/samples/images/solidus_tshirt_back_blue.png

--- a/solidus_importer.gemspec
+++ b/solidus_importer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio-contrib/solidus_importer'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio-contrib/solidus_importer/releases'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
+  spec.required_ruby_version = Gem::Requirement.new('> 2.5')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Relax Ruby version requirement to support Ruby 3
Add note to readme about using git repo since that version is behind
[Fix typo in header column of example file](https://github.com/solidusio-contrib/solidus_importer/commit/4bd278ffda8bc58cf6cbd2580b8cc3a02a304de5)