### PR TITLE
Fix Broken Test related to CSVFormatValidators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .sass-cache
 coverage
 Gemfile.lock
+Gemfile-local
 tmp
 nbproject
 pkg

--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'csv_format_validators/empty_headers'
+
 module SolidusImporter
   class Configuration < Spree::Preferences::Configuration
     preference :solidus_importer, :hash, default: {
@@ -67,7 +69,7 @@ module SolidusImporter
     #     end
     #   end
     # ]
-    preference :csv_format_validators, :array, default: []
+    preference :csv_format_validators, :array, default: [::SolidusImporter::CsvFormatValidators::EmptyHeaders]
   end
 
   class << self


### PR DESCRIPTION
The default was empty array, which conflicts with the default behavior as covered through the specs.