### PR TITLE
Fix broken specs

### DIFF
--- a/spec/features/solidus_importer/import_spec.rb
+++ b/spec/features/solidus_importer/import_spec.rb
@@ -18,9 +18,11 @@ RSpec.describe 'Import from CSV files' do
     let(:csv_file_rows) { 4 }
     let(:user_emails) { ['jane.doe@acme.com', 'john.doe@acme.com'] }
     let(:imported_customer) { Spree::User.last }
-    let(:state) { create(:state, abbr: 'ON', country_iso: 'CA') }
 
-    before { state }
+    # rubocop:disable RSpec/LetSetup
+    let!(:state_on) { create(:state, abbr: 'ON', country_iso: 'CA') }
+    let!(:state_qc) { create(:state, abbr: 'QC', country_iso: 'CA') }
+    # rubocop:enable RSpec/LetSetup
 
     it 'imports some customers' do
       expect { import }.to change(Spree::User, :count).by(2)

--- a/spec/lib/solidus_importer/processors/customer_spec.rb
+++ b/spec/lib/solidus_importer/processors/customer_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe SolidusImporter::Processors::Customer do
       let(:result) { context.merge(user: Spree::User.last) }
 
       it 'creates a new user' do
-        expect { described_method }.to change { Spree::User.count }.by(1)
+        expect { described_method }.to change(Spree::User, :count).by(1)
         expect(described_method).to eq(result)
       end
 
@@ -59,7 +59,7 @@ RSpec.describe SolidusImporter::Processors::Customer do
         before { allow(Spree::User).to receive(:find_or_initialize_by).and_return(user) }
 
         it 'updates the user' do
-          expect { described_method }.not_to(change { Spree::User.count })
+          expect { described_method }.not_to(change(Spree::User, :count))
           expect(described_method).to eq(result)
         end
       end

--- a/spec/lib/solidus_importer/processors/product_spec.rb
+++ b/spec/lib/solidus_importer/processors/product_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SolidusImporter::Processors::Product do
       before { shipping_category }
 
       it 'creates a new product' do
-        expect { described_method }.to change { Spree::Product.count }.by(1)
+        expect { described_method }.to change(Spree::Product, :count).by(1)
         expect(described_method).to eq(result)
         expect(product).not_to be_available
       end
@@ -58,7 +58,7 @@ RSpec.describe SolidusImporter::Processors::Product do
         let!(:product) { create(:product, slug: data['Handle']) }
 
         it 'updates the product' do
-          expect { described_method }.not_to(change { Spree::Product.count })
+          expect { described_method }.not_to(change(Spree::Product, :count))
           expect(described_method).to eq(result)
           expect(product.reload.name).to eq('A product name')
         end

--- a/spec/lib/solidus_importer/processors/variant_spec.rb
+++ b/spec/lib/solidus_importer/processors/variant_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SolidusImporter::Processors::Variant do
         before { data.merge! 'Option1 Value' => 'Some value' }
 
         it 'creates a new variant' do
-          expect { described_method }.to change { Spree::Variant.count }.by(1)
+          expect { described_method }.to change(Spree::Variant, :count).by(1)
           expect(described_method).to eq(result)
           expect(product.variants.first.weight).to eq 20.0
           expect(product.variants.first.price).to eq 60.5
@@ -49,7 +49,7 @@ RSpec.describe SolidusImporter::Processors::Variant do
         before { data.merge! 'Option1 Value' => 'Default Title' }
 
         it 'updates master variant' do
-          expect { described_method }.not_to(change { Spree::Variant.count })
+          expect { described_method }.not_to(change(Spree::Variant, :count))
           expect(described_method).to eq(result)
           expect(product.master.weight).to eq 20.0
           expect(product.master.price).to eq 60.5
@@ -62,7 +62,7 @@ RSpec.describe SolidusImporter::Processors::Variant do
         before { data.merge! 'Option1 Value' => nil }
 
         it 'updates master variant' do
-          expect { described_method }.not_to(change { Spree::Variant.count })
+          expect { described_method }.not_to(change(Spree::Variant, :count))
           expect(described_method).to eq(result)
           expect(product.master.weight).to eq 20.0
           expect(product.master.price).to eq 60.5
@@ -76,7 +76,7 @@ RSpec.describe SolidusImporter::Processors::Variant do
         before { data.merge! 'Option1 Value' => 'Some value' }
 
         it 'updates the variant' do
-          expect { described_method }.not_to(change { Spree::Variant.count })
+          expect { described_method }.not_to(change(Spree::Variant, :count))
           expect(described_method).to eq(result)
           expect(variant.reload.weight.to_f).to eq(data['Variant Weight'])
           expect(variant.reload.price).to eq(data['Variant Price'])


### PR DESCRIPTION
Specs were failing so I took a stab at fixing them. Seem to be related to `Spree::Address`. I could be wrong on some of these as I was not the original author so please let me know if I misinterpreted the intention of these specs. But hey, at least all the specs run now!

The issue with `import_spec.rb` was that the CSV file being imported contained two customers that lived in two separate provinces, however the spec was only creating a single province. Creating both provinces resolved that issue.

The issue with `customer_address_spec.rb` was more tricky. I'm no expert, but it seems that the factory cannot create a state in the incorrect country. So I created a valid state, then updated it to associate it with the wrong country.

The second issue with that spec seemed to be written for when the country does not have the state specified in the imported record.