### PR TITLE
Update solidus_importer for compatibility with Solidus 4

### DIFF
--- a/solidus_importer.gemspec
+++ b/solidus_importer.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
+  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
   spec.add_dependency 'solidus_support', '~> 0.5'
 
   spec.add_development_dependency 'solidus_dev_support', '~> 2.4'


### PR DESCRIPTION
The solidus_importer.gemspec originally required a Solidus version below 4. I updated the version requirement to ensure compatibility with the new Solidus version 4.