### PR TITLE
Define ransackable_attributes for Import and Row

### DIFF
--- a/app/models/solidus_importer/import.rb
+++ b/app/models/solidus_importer/import.rb
@@ -39,6 +39,10 @@ module SolidusImporter
       self.file = File.open(path, 'r')
     end
 
+    def self.ransackable_attributes(_auth_object = nil)
+      ["created_at", "file", "file_content_type", "file_file_name", "file_file_size", "file_updated_at", "id", "id_value", "import_type", "messages", "state", "updated_at"]
+    end
+
     class << self
       def available_types
         SolidusImporter::Import.select(:import_type).order(:import_type).group(:import_type).pluck(:import_type)

--- a/app/models/solidus_importer/row.rb
+++ b/app/models/solidus_importer/row.rb
@@ -22,5 +22,9 @@ module SolidusImporter
 
     validates :data, presence: true, allow_blank: false
     validates :state, presence: true, allow_blank: false
+
+    def self.ransackable_attributes(_auth_object = nil)
+      ["created_at", "data", "id", "id_value", "import_id", "messages", "state", "updated_at"]
+    end
   end
 end


### PR DESCRIPTION
With a fresh install of Solidus and the solidus_importer gem (using `gem "solidus_importer", github: "solidusio-contrib/solidus_importer"`), navigating to the import page in the admin GUI results in this RuntimeError:

> RuntimeError in Spree::Admin::SolidusImporter::Imports#index
> Showing `/Users/malak/.gem/ruby/3.3.2/bundler/gems/solidus_importer-109f0c1f9790/app/views/spree/admin/solidus_importer/imports/index.html.erb` where line #16 raised:
> 
> Ransack needs SolidusImporter::Import attributes explicitly allowlisted as
searchable. Define a `ransackable_attributes` class method in your `SolidusImporter::Import`
model, watching out for items you DON'T want searchable (for
example, `encrypted_password`, `password_reset_token`, `owner` or
other sensitive information). You can use the following as a base:
> 
> ```ruby
> class SolidusImporter::Import < ApplicationRecord
> 
>   # ...
> 
>   def self.ransackable_attributes(auth_object = nil)
>     ["created_at", "file", "file_content_type", "file_file_name", "file_file_size", "file_updated_at", "id", "id_value", "import_type", "messages", "state", "updated_at"]
>   end
> 
>   # ...
> 
> end
> ```
> 

I have tested that this fix works in my environment.

---

When I run `bundle exec rspec` it says `0 examples, 0 failures` so I'm not sure where to go to update the "Run specs on supported Solidus versions" that's failing on this PR.