### PR TITLE
Fix deprecation warning

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -10,4 +10,7 @@ Spree::Backend::Config.configure do |config|
   )
 end
 
-MIME::Types.add(MIME::Type.new(["application/csv", "csv"]), true)
+MIME::Types.add(
+  MIME::Type.new("content-type" => "application/csv", "extensions" => ["csv"]),
+  true
+)

--- a/solidus_importer.gemspec
+++ b/solidus_importer.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "solidus_core", [">= 2.0.0", "< 5"]
   spec.add_dependency "solidus_support", "~> 0.5"
   spec.add_dependency "standard", "~> 1.49"
+  spec.add_dependency "mime-types", ">= 2"
 
   spec.add_development_dependency "solidus_dev_support", "~> 2.4"
 end


### PR DESCRIPTION
MIME::Type now expects a hash of arguments for its constructor.