### PR TITLE
Avoid deprecation warnings when constructing menu items

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -1,13 +1,22 @@
 # frozen_string_literal: true
 
 Spree::Backend::Config.configure do |config|
-  config.menu_items << config.class::MenuItem.new(
-    :imports,
-    "download",
-    condition: -> { can?(:admin, Spree::Product) },
-    label: :importer,
-    url: :admin_solidus_importer_imports_path
-  )
+  config.menu_items << if Spree.solidus_gem_version < Gem::Version.new("4.2.0")
+    config.class::MenuItem.new(
+      :imports,
+      "download",
+      condition: -> { can?(:admin, Spree::Product) },
+      label: :importer,
+      url: :admin_solidus_importer_imports_path
+    )
+  else
+    config.class::MenuItem.new(
+      icon: "download",
+      condition: -> { can?(:admin, Spree::Product) },
+      label: :importer,
+      url: :admin_solidus_importer_imports_path
+    )
+  end
 end
 
 MIME::Types.add(


### PR DESCRIPTION
The old behaviour was deprecated in https://github.com/solidusio/solidus/pull/5309 which was released as part of [4.2.0](https://github.com/solidusio/solidus/blob/main/CHANGELOG.md#solidus-v420-2023-09-29).

I opted for the conditional since that seemed much lower impact than bumping the minimum required version.